### PR TITLE
Fixed version parsing and comparison for issue #2

### DIFF
--- a/src/app/modules/home/home.controller.js
+++ b/src/app/modules/home/home.controller.js
@@ -93,8 +93,7 @@ class HomeCtrl {
         this._$http.get("https://api.github.com/repos/bad-weather-corp/NEMWallet/releases/latest").then((res) => {
             let currentVersion = this._AppConstants.version;
             let version = res.data.name;
-            let isVersion2 = parseInt(version.split(".")[0]) > 1;
-            if (isVersion2 && Helpers.versionCompare(currentVersion, version) < 0) {
+            if (Helpers.versionCompare(currentVersion, version) < 0) {
                 this.newUpdate = true;
                 this.updateInfo = res.data;
             }

--- a/tests/specs/helpers.spec.js
+++ b/tests/specs/helpers.spec.js
@@ -1,0 +1,27 @@
+import Helpers from '../../src/app/utils/helpers';
+
+describe('Helper versioning', function() {
+
+    it("Simple version", function() {
+        expect(Helpers.versionCompare("1.2.3", "1.2.2")>0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "1.3.1")<0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "2.1.1")<0).toBe(true);
+        expect(Helpers.versionCompare("11.2.3", "5.2.2")>0).toBe(true);
+
+        expect(Helpers.versionCompare("1.2.3", "1.2.3")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "1.2.3+other")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "1.2.3+other comment")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "1.2.3 comment")==0).toBe(true);
+
+        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3+other")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3+other comment")==0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3 comment")==0).toBe(true);
+    });
+    it("Pre-release version parsing", function() {
+        expect(Helpers.versionCompare("1.2.3-alpha", "1.2.3")<0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3", "1.2.3-alpha")>0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3-alpha+meta.1", "1.2.3")<0).toBe(true);
+        expect(Helpers.versionCompare("1.2.3-alpha+meta.1 comment", "1.2.3")<0).toBe(true);
+    });
+});

--- a/tests/specs/helpers.spec.js
+++ b/tests/specs/helpers.spec.js
@@ -2,26 +2,51 @@ import Helpers from '../../src/app/utils/helpers';
 
 describe('Helper versioning', function() {
 
-    it("Simple version", function() {
-        expect(Helpers.versionCompare("1.2.3", "1.2.2")>0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "1.3.1")<0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "2.1.1")<0).toBe(true);
-        expect(Helpers.versionCompare("11.2.3", "5.2.2")>0).toBe(true);
+    function testVersions(first, second, result) {
+        it("Version " + first + " minus " + second + " is " + result, function() {
+            expect(Math.sign(Helpers.versionCompare(first, second)) == result).toBe(true);
+        })  
+    };
 
-        expect(Helpers.versionCompare("1.2.3", "1.2.3")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "1.2.3+other")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "1.2.3+other comment")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "1.2.3 comment")==0).toBe(true);
-
-        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3+other")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3+other comment")==0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3+meta", "1.2.3 comment")==0).toBe(true);
-    });
-    it("Pre-release version parsing", function() {
-        expect(Helpers.versionCompare("1.2.3-alpha", "1.2.3")<0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3", "1.2.3-alpha")>0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3-alpha+meta.1", "1.2.3")<0).toBe(true);
-        expect(Helpers.versionCompare("1.2.3-alpha+meta.1 comment", "1.2.3")<0).toBe(true);
-    });
+    // simple tests to make sure parsing works
+    testVersions("1.2.3", "1.2.2", 1);
+    testVersions("1.2.3", "1.2.2", 1);
+    testVersions("1.2.3", "1.3.1", -1);
+    testVersions("1.2.3", "2.1.1", -1);
+    testVersions("11.2.3", "5.2.2", 1);
+    testVersions("1.2.3", "1.2.3", 0);
+    testVersions("1.2.3", "1.2.3+other", 0);
+    testVersions("1.2.3", "1.2.3+other comment", 0);
+    testVersions("1.2.3", "1.2.3 comment", 0);
+    // couple of metadata tests
+    testVersions("1.2.3+meta", "1.2.3+other", 0);
+    testVersions("1.2.3+meta", "1.2.3", 0);
+    testVersions("1.2.3+meta", "1.2.3+other comment", 0);
+    testVersions("1.2.3+meta", "1.2.3 comment", 0);
+    testVersions("1.2.3-alpha", "1.2.3", -1);
+    // prerelease tests
+    testVersions("1.2.3", "1.2.3-alpha", 1);
+    testVersions("1.2.3-alpha+meta.1", "1.2.3", -1);
+    testVersions("1.2.3-alpha+meta.1 comment", "1.2.3", -1);
+    //// following tests represent examples from the semver page
+    // basic major, minor, patch
+    testVersions("1.0.0", "2.0.0", -1);
+    testVersions("2.0.0", "2.1.0", -1);
+    testVersions("2.1.0", "2.1.1", -1);
+    // prerelease tests
+    testVersions("1.0.0-alpha", "1.0.0-alpha.1", -1);
+    testVersions("1.0.0-alpha.1", "1.0.0-alpha.beta", -1);
+    testVersions("1.0.0-alpha.beta", "1.0.0-beta", -1);
+    testVersions("1.0.0-beta", "1.0.0-beta.2", -1);
+    testVersions("1.0.0-beta.2", "1.0.0-beta.11", -1);
+    testVersions("1.0.0-beta.11", "1.0.0-rc.1", -1);
+    testVersions("1.0.0-rc.1", "1.0.0", -1);
+    // reversed prerelease tests
+    testVersions("1.0.0-alpha.1", "1.0.0-alpha", 1);
+    testVersions("1.0.0-alpha.beta", "1.0.0-alpha.1", 1);
+    testVersions("1.0.0-beta", "1.0.0-alpha.beta", 1);
+    testVersions("1.0.0-beta.2", "1.0.0-beta", 1);
+    testVersions("1.0.0-beta.11", "1.0.0-beta.2", 1);
+    testVersions("1.0.0-rc.1", "1.0.0-beta.11", 1);
+    testVersions("1.0.0", "1.0.0-rc.1", 1);
 });


### PR DESCRIPTION
Versions are now parsed and compared per semver2 spec with addition of comment segment separated from the version by a space. 

Full version can look like this "2.3.4-alpha.2+security.critical Important fixes"